### PR TITLE
Drop EoL Ruby 2.4 from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: "2.4"
           - ruby: "2.5"
           - ruby: "2.6"
           - ruby: "2.7"


### PR DESCRIPTION
This should have been excluded from the beginning and was a typo.