### PR TITLE
Pull in gcg only on Ruby 2.5 and newer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :release do
-  gem 'github_changelog_generator', '>= 1.16.4', :require => false
+  gem 'github_changelog_generator', '>= 1.16.4', :require => false if RUBY_VERSION >= '2.5'
 end


### PR DESCRIPTION
Older versions of the changelog generator have different issues Vox
Pupuli run into. Our CI also tests on Ruby 2.4 but latest gcg requires
Ruby 2.5.