### PR TITLE
Add puppet-lint-top_scope_facts-check

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint-file_ensure-check'
   s.add_runtime_dependency 'puppet-lint-strict_indent-check'
   s.add_runtime_dependency 'puppet-lint-optional_default-check'
+  s.add_runtime_dependency 'puppet-lint-top_scope_facts-check'
 end


### PR DESCRIPTION
I did some tests on our modules and didn't notice any false positives.
https://github.com/mmckinst maintains two plugins. We already use their
awesome puppet-lint-legacy_facts-check plugin.
puppet-lint-top_scope_facts-check is a good addition to it. This points
out facts being accessed via top scope like `${::kernel}`. Most of the
occurrences can also be autofixed.