### PR TITLE
Add puppet-lint-lookup_in_parameter-check

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint-strict_indent-check'
   s.add_runtime_dependency 'puppet-lint-optional_default-check'
   s.add_runtime_dependency 'puppet-lint-top_scope_facts-check'
+  s.add_runtime_dependency 'puppet-lint-lookup_in_parameter-check'
 end


### PR DESCRIPTION
A puppet-lint plugin to check for calls to `lookup` in parameters.