### PR TITLE
Add puppet-lint-params_empty_string-check

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint-manifest_whitespace-check'
   s.add_runtime_dependency 'puppet-lint-optional_default-check'
   s.add_runtime_dependency 'puppet-lint-param-docs'
+  s.add_runtime_dependency 'puppet-lint-params_empty_string-check'
   s.add_runtime_dependency 'puppet-lint-param-types'
   s.add_runtime_dependency 'puppet-lint-resource_reference_syntax'
   s.add_runtime_dependency 'puppet-lint-strict_indent-check'


### PR DESCRIPTION
Based on our style guide, variables should default to `{}`, `[]` or
undef or a default value, but not an empty string. To enforce that we
can use our own puppet-lint plugin.