### PR TITLE
Drop puppet-lint-params_empty_string-check

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint-lookup_in_parameter-check'
   s.add_runtime_dependency 'puppet-lint-manifest_whitespace-check'
   s.add_runtime_dependency 'puppet-lint-optional_default-check'
-  s.add_runtime_dependency 'puppet-lint-params_empty_string-check'
   s.add_runtime_dependency 'puppet-lint-resource_reference_syntax'
   s.add_runtime_dependency 'puppet-lint-strict_indent-check'
   s.add_runtime_dependency 'puppet-lint-top_scope_facts-check'


### PR DESCRIPTION
This was merged by accident in
https://github.com/voxpupuli/voxpupuli-puppet-lint-plugins/pull/9. It
will be revied in
https://github.com/voxpupuli/voxpupuli-puppet-lint-plugins/pull/8