### PR TITLE
Add rubocop-rake

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
 AllCops:
   NewCops: enable
   TargetRubyVersion: 2.4
+require: rubocop-rake

--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 13.0'
   # pull in older rubocop. Newer doesn't support ruby 2.4
   s.add_development_dependency 'rubocop', '~> 1.12.0'
+  s.add_development_dependency 'rubocop-rake'
 end


### PR DESCRIPTION
rubocop suggests this plugin:

```
$ bundle exec rake rubocop:auto_correct
Running RuboCop...
Inspecting 3 files
...

3 files inspected, no offenses detected

Tip: Based on detected gems, the following RuboCop extension libraries
might be helpful:
  * rubocop-rake (https://github.com/rubocop/rubocop-rake)

  You can opt out of this message by adding the following to your config
  (see
  https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions
  for more options):
    AllCops:
        SuggestExtensions: false
```