### PR TITLE
gemspec: Fix license format to be SPDX compliant

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/voxpupuli/voxpupuli-puppet-lint-plugins'
   s.summary     = 'Helper Gem that pulls in all the puppet-lint plugins that Vox Pupuli uses'
   s.description = 'A package that depends on all the puppet-lint-* gems Vox Pupuli modules need and puppet-lint itself'
-  s.licenses    = 'AGPL-3'
+  s.licenses    = 'AGPL-3.0'
 
   # some of the plugins claim to require Ruby 2.4.0 or newer
   s.required_ruby_version = '>= 2.4.0'


### PR DESCRIPTION
without this, gem build yells at us:

```
WARNING:  license value 'AGPL-3' is invalid.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
Did you mean 'AGPL-3.0'?
```