### PR TITLE
Drop classes_and_types_beginning_with_digits-check

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint', '>= 2.5.0'
   s.add_runtime_dependency 'puppet-lint-absolute_classname-check', '~> 3.1'
   s.add_runtime_dependency 'puppet-lint-anchor-check', '~> 1.1'
-  s.add_runtime_dependency 'puppet-lint-classes_and_types_beginning_with_digits-check', '~> 1.0'
   s.add_runtime_dependency 'puppet-lint-file_ensure-check', '~> 1.1'
   s.add_runtime_dependency 'puppet-lint-leading_zero-check', '~> 1.0'
   s.add_runtime_dependency 'puppet-lint-legacy_facts-check', '>= 1.0.4', '< 2.0.0'


### PR DESCRIPTION
The puppet-lint-classes_and_types_beginning_with_digits-check puppet-lint plugin is archived and not maintained anymore. Also it's not required anymore. The same functionality is embedded in the puppet parser validate face, so this should not even be a breaking change.