### PR TITLE
puppet-lint-param-types: Allow 1.x

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint-optional_default-check', '~> 1.1'
   s.add_runtime_dependency 'puppet-lint-param-docs', '>= 1.7.6', '< 2.0.0'
   s.add_runtime_dependency 'puppet-lint-params_empty_string-check', '~> 1.0'
-  s.add_runtime_dependency 'puppet-lint-param-types', '~> 0.0'
+  s.add_runtime_dependency 'puppet-lint-param-types', '~> 1.0'
   s.add_runtime_dependency 'puppet-lint-resource_reference_syntax', '~> 1.1'
   s.add_runtime_dependency 'puppet-lint-strict_indent-check', '~> 2.1'
   s.add_runtime_dependency 'puppet-lint-top_scope_facts-check', '>= 1.0.1', '< 2.0.0'


### PR DESCRIPTION
The 1.0.0 release of puppet-lint-param-types is the first one after the migration to Vox Pupuli. Also it allows puppet-lint 3.