### PR TITLE
rubocop-rake: Pin to 0.5.x

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -38,5 +38,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '>= 13.0'
   # pull in older rubocop. Newer doesn't support ruby 2.4
   s.add_development_dependency 'rubocop', '~> 1.12.0'
-  s.add_development_dependency 'rubocop-rake'
+  # with 0.6.0 Ruby 2.4 support was dropped
+  s.add_development_dependency 'rubocop-rake', '~> 0.5.1'
 end


### PR DESCRIPTION
Newer versions require Ruby 2.5 or newer