### PR TITLE
Require puppet-lint 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: "2.4"
           - ruby: "2.5"
           - ruby: "2.6"
           - ruby: "2.7"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 require: rubocop-rake
+
+Gemspec/RequireMFA:
+  Enabled: False

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ RuboCop::RakeTask.new(:rubocop) do |task|
   task.options = ['--display-cop-names', '--display-style-guide', '--extra-details']
 
   # Use Rubocop's Github Actions formatter if possible
-  task.formatters << 'github' if ENV['GITHUB_ACTIONS'] == 'true'
+  task.formatters << 'github' if ENV.fetch('GITHUB_ACTIONS', nil) == 'true'
 end
 
 task default: [:rubocop]

--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |s|
   s.description = 'A package that depends on all the puppet-lint-* gems Vox Pupuli modules need and puppet-lint itself'
   s.licenses    = 'AGPL-3.0'
 
-  # some of the plugins claim to require Ruby 2.4.0 or newer
-  s.required_ruby_version = '>= 2.4.0'
+  # puppet-lint 3.1 requires Ruby 2.5 and newer. Also Ruby 2.5 is in Puppet 6 AIO
+  s.required_ruby_version = '>= 2.5.0'
 
   # pull in puppet-lint 2.5.0; required for Ruby 3 support
   s.add_runtime_dependency 'puppet-lint', '>= 2.5.0'
@@ -36,8 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint-version_comparison-check', '~> 1.1'
 
   s.add_development_dependency 'rake', '>= 13.0'
-  # pull in older rubocop. Newer doesn't support ruby 2.4
-  s.add_development_dependency 'rubocop', '~> 1.12.0'
-  # with 0.6.0 Ruby 2.4 support was dropped
-  s.add_development_dependency 'rubocop-rake', '~> 0.5.1'
+  # pull in older rubocop. Newer doesn't support ruby 2.5
+  s.add_development_dependency 'rubocop', '~> 1.28.0'
+  s.add_development_dependency 'rubocop-rake', '~> 0.6.0'
 end

--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -13,13 +13,13 @@ Gem::Specification.new do |s|
   # puppet-lint 3.1 requires Ruby 2.5 and newer. Also Ruby 2.5 is in Puppet 6 AIO
   s.required_ruby_version = '>= 2.5.0'
 
-  # pull in puppet-lint 2.5.0; required for Ruby 3 support
-  s.add_runtime_dependency 'puppet-lint', '>= 2.5.0'
+  # pull in puppet-lint 3.1 or newer. Required for code annotations in GitHub
+  # Also it vendors top_scope_facts-check and legacy_facts-check
+  s.add_runtime_dependency 'puppet-lint', '~> 3.1'
   s.add_runtime_dependency 'puppet-lint-absolute_classname-check', '~> 3.1'
   s.add_runtime_dependency 'puppet-lint-anchor-check', '~> 1.1'
   s.add_runtime_dependency 'puppet-lint-file_ensure-check', '~> 1.1'
   s.add_runtime_dependency 'puppet-lint-leading_zero-check', '~> 1.0'
-  s.add_runtime_dependency 'puppet-lint-legacy_facts-check', '>= 1.0.4', '< 2.0.0'
   s.add_runtime_dependency 'puppet-lint-lookup_in_parameter-check', '~> 1.0'
   s.add_runtime_dependency 'puppet-lint-manifest_whitespace-check', '~> 0.2.7', '< 1.0.0'
   s.add_runtime_dependency 'puppet-lint-optional_default-check', '~> 1.1'
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint-param-types', '~> 1.0'
   s.add_runtime_dependency 'puppet-lint-resource_reference_syntax', '~> 1.1'
   s.add_runtime_dependency 'puppet-lint-strict_indent-check', '~> 2.1'
-  s.add_runtime_dependency 'puppet-lint-top_scope_facts-check', '>= 1.0.1', '< 2.0.0'
   s.add_runtime_dependency 'puppet-lint-topscope-variable-check', '~> 1.1'
   s.add_runtime_dependency 'puppet-lint-trailing_comma-check', '~> 1.0'
   s.add_runtime_dependency 'puppet-lint-unquoted_string-check', '~> 2.2'


### PR DESCRIPTION
    require puppet-lint 3.1; drop top_scope_facts/legacy_facts check

    puppet-lint-top_scope_facts-check got vendored into puppet-lint 3.1:
    https://github.com/puppetlabs/puppet-lint/pull/85

    puppet-lint-legacy_facts-check got vendored into puppet-lint 3.1:
    https://github.com/puppetlabs/puppet-lint/pull/91


also contains #36 