### PR TITLE
(MAINT) Update puppet-lint dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: "2.5"
-          - ruby: "2.6"
           - ruby: "2.7"
           - ruby: "3.0"
           - ruby: "3.1"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 require: rubocop-rake
 
 Gemspec/RequireMFA:

--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -10,12 +10,11 @@ Gem::Specification.new do |s|
   s.description = 'A package that depends on all the puppet-lint-* gems Vox Pupuli modules need and puppet-lint itself'
   s.licenses    = 'AGPL-3.0'
 
-  # puppet-lint 3.1 requires Ruby 2.5 and newer. Also Ruby 2.5 is in Puppet 6 AIO
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   # pull in puppet-lint 3.1 or newer. Required for code annotations in GitHub
   # Also it vendors top_scope_facts-check and legacy_facts-check
-  s.add_runtime_dependency 'puppet-lint', '~> 3.1'
+  s.add_runtime_dependency 'puppet-lint', '~> 4.0.0.rc'
   s.add_runtime_dependency 'puppet-lint-absolute_classname-check', '~> 3.1'
   s.add_runtime_dependency 'puppet-lint-anchor-check', '~> 1.1'
   s.add_runtime_dependency 'puppet-lint-file_ensure-check', '~> 1.1'


### PR DESCRIPTION
This change introduces puppet-lint v4.0.0.rc.x to enable the testing with newer versions of Puppet tooling.

This is more to prompt discussion about how we handle the upgrade and testing.