### PR TITLE
voxpupuli-rubocop: Update to 2.0->2.8.0

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puppet-lint-version_comparison-check', '~> 2.0'
 
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
-  s.add_development_dependency 'voxpupuli-rubocop', '~> 2.0'
+  s.add_development_dependency 'voxpupuli-rubocop', '~> 2.8.0'
 end


### PR DESCRIPTION
On all projects we already pin to the patch release to ensure dependabot informs us about updates in a PR.