### PR TITLE
Add puppet-lint-package_ensure-check check

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'puppet-lint-lookup_in_parameter-check', '~> 2.0'
   s.add_dependency 'puppet-lint-manifest_whitespace-check', '~> 1.0'
   s.add_dependency 'puppet-lint-optional_default-check', '~> 2.0'
+  s.add_dependency 'puppet-lint-package_ensure-check', '~> 0.2'
   s.add_dependency 'puppet-lint-param-docs', '~> 2.0'
   s.add_dependency 'puppet-lint-params_empty_string-check', '~> 2.0'
   s.add_dependency 'puppet-lint-param-types', '~> 2.0'


### PR DESCRIPTION
I think it makes sense to add puppet-lint-package_ensure-check. It ensures that package resources don't have `ensure => latest`. This is a common best practice since ages, but we never enforced it with a puppet-lint plugin. I think we should add it. I would like to collect a few opinions before we merge it.