### PR TITLE
Update `puppet-lint-manifest_whitespace-check` from `~> 0.3, < 1.0.0` to `~> 1.0`

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'puppet-lint-file_ensure-check', '~> 2.0'
   s.add_dependency 'puppet-lint-leading_zero-check', '~> 2.0'
   s.add_dependency 'puppet-lint-lookup_in_parameter-check', '~> 2.0'
-  s.add_dependency 'puppet-lint-manifest_whitespace-check', '~> 0.3', '< 1.0.0'
+  s.add_dependency 'puppet-lint-manifest_whitespace-check', '~> 1.0'
   s.add_dependency 'puppet-lint-optional_default-check', '~> 2.0'
   s.add_dependency 'puppet-lint-param-docs', '~> 2.0'
   s.add_dependency 'puppet-lint-params_empty_string-check', '~> 2.0'


### PR DESCRIPTION
See https://github.com/voxpupuli/puppet-lint-manifest_whitespace-check/blob/master/CHANGELOG.md#100-2023-04-22
