### PR TITLE
Add puppet-lint-exec_idempotency-check

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'puppet-lint', '~> 5.1'
   s.add_dependency 'puppet-lint-absolute_classname-check', '~> 5.0'
   s.add_dependency 'puppet-lint-anchor-check', '~> 3.0'
+  s.add_dependency 'puppet-lint-exec_idempotency-check', '~> 2.0'
   s.add_dependency 'puppet-lint-file_ensure-check', '~> 3.0'
   s.add_dependency 'puppet-lint-leading_zero-check', '~> 3.0'
   s.add_dependency 'puppet-lint-lookup_in_parameter-check', '~> 3.0'


### PR DESCRIPTION
What does the plugin do?

When using `exec` resource it is highly recommended to take care on idempotency. That means, that we need a check to verify if the command should be run again or is required to run at all.

The following attributes control this behavior:

- `creates`: checks if a directory or file exists
- `onlyif` or `unless`: execute checks to verify idempotency
- `refreshonly`: only run the exec if it is triggered by another reosurce

This is part of the puppet best practices since a long time, we just never had a linter to verify it.