### PR TITLE
Add puppet-lint-params_not_optional_with_undef-check

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'puppet-lint-package_ensure-check', '~> 0.2'
   s.add_dependency 'puppet-lint-param-docs', '~> 3.0'
   s.add_dependency 'puppet-lint-params_empty_string-check', '~> 3.0'
+  s.add_dependency 'puppet-lint-params_not_optional_with_undef-check', '~> 1.0'
   s.add_dependency 'puppet-lint-param-types', '~> 3.0'
   s.add_dependency 'puppet-lint-resource_reference_syntax', '~> 3.0'
   s.add_dependency 'puppet-lint-strict_indent-check', '~> 5.0'


### PR DESCRIPTION
This adds a puppet-lint plugin to check for parameters without Optional as type but `undef` as value.

According the the Vox Pupuli best practices, a class parameter with the string datatype should default to `undef` and not `''`, if it's `Optional[]`. The recommendations are documented at [voxpupuli.org](https://voxpupuli.org/docs/reviewing_pr/).