### PR TITLE
Add puppet-lint-stdlib_deprecations gem

### DIFF
--- a/voxpupuli-puppet-lint-plugins.gemspec
+++ b/voxpupuli-puppet-lint-plugins.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'puppet-lint-params_not_optional_with_undef-check', '~> 1.0'
   s.add_dependency 'puppet-lint-param-types', '~> 3.0'
   s.add_dependency 'puppet-lint-resource_reference_syntax', '~> 3.0'
+  s.add_dependency 'puppet-lint-stdlib_deprecations', '~> 0.0.5'
   s.add_dependency 'puppet-lint-strict_indent-check', '~> 5.0'
   s.add_dependency 'puppet-lint-topscope-variable-check', '~> 3.0'
   s.add_dependency 'puppet-lint-trailing_comma-check', '~> 3.0'


### PR DESCRIPTION
## Summary
- Adds `puppet-lint-stdlib_deprecations` gem as a dependency
- Helps identify deprecated and removed `puppetlabs-stdlib` functions during upgrades to stdlib 9.x and Puppet 8

Fixes #83

## Test plan
- [ ] CI passes and gem builds successfully